### PR TITLE
Traduction en français de Cicero dans le fichier 'phi0474/_cts_.xml'

### DIFF
--- a/data/phi0474/__cts__.xml
+++ b/data/phi0474/__cts__.xml
@@ -1,4 +1,5 @@
 <ti:textgroup xmlns:ti="http://chs.harvard.edu/xmlns/cts" projid="latinLit:phi0474" urn="urn:cts:latinLit:phi0474">
         <ti:groupname xml:lang="eng">Cicero</ti:groupname>
+        <ti:groupname xml:lang="fr">Cicéron</ti:groupname>
         </ti:textgroup>
     


### PR DESCRIPTION
Je suggère l'ajout de la traduction française du nom "Cicero" dans le fichier 'phi0474/_cts_.xml'.